### PR TITLE
Add `--quiet` flag to local 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,14 @@ name: CI
 
 on:
   push:
-    branches:    
+    branches:
       - '**'
     tags-ignore:
       - v*
+  pull_request:
+    paths-ignore:
+      - 'LICENSE'
+      - '**.md'
 
 jobs:
   format:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ $ ruby -v
 - versions: Lists installed Ruby versions.
 - global: Sets the global Ruby version.
 - local: Sets the current Ruby version.
+    - -q, --quiet: Supress error messages when `.ruby-version` is missing
 
 ## Installation
 

--- a/completions/frum.bash
+++ b/completions/frum.bash
@@ -12,7 +12,7 @@ _frum() {
             frum)
                 cmd="frum"
                 ;;
-
+            
             completions)
                 cmd+="__completions"
                 ;;
@@ -50,7 +50,7 @@ _frum() {
                 return 0
             fi
             case "${prev}" in
-
+                
                 *)
                     COMPREPLY=()
                     ;;
@@ -58,7 +58,7 @@ _frum() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-
+        
         frum__completions)
             opts=" -l -h -V -s  --list --help --version --shell  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
@@ -66,7 +66,7 @@ _frum() {
                 return 0
             fi
             case "${prev}" in
-
+                
                 --shell)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -89,7 +89,7 @@ _frum() {
                 return 0
             fi
             case "${prev}" in
-
+                
                 *)
                     COMPREPLY=()
                     ;;
@@ -104,7 +104,7 @@ _frum() {
                 return 0
             fi
             case "${prev}" in
-
+                
                 *)
                     COMPREPLY=()
                     ;;
@@ -119,7 +119,7 @@ _frum() {
                 return 0
             fi
             case "${prev}" in
-
+                
                 *)
                     COMPREPLY=()
                     ;;
@@ -134,7 +134,7 @@ _frum() {
                 return 0
             fi
             case "${prev}" in
-
+                
                 *)
                     COMPREPLY=()
                     ;;
@@ -149,7 +149,7 @@ _frum() {
                 return 0
             fi
             case "${prev}" in
-
+                
                 *)
                     COMPREPLY=()
                     ;;
@@ -164,7 +164,7 @@ _frum() {
                 return 0
             fi
             case "${prev}" in
-
+                
                 *)
                     COMPREPLY=()
                     ;;
@@ -179,7 +179,7 @@ _frum() {
                 return 0
             fi
             case "${prev}" in
-
+                
                 *)
                     COMPREPLY=()
                     ;;

--- a/completions/frum.bash
+++ b/completions/frum.bash
@@ -12,7 +12,7 @@ _frum() {
             frum)
                 cmd="frum"
                 ;;
-            
+
             completions)
                 cmd+="__completions"
                 ;;
@@ -50,7 +50,7 @@ _frum() {
                 return 0
             fi
             case "${prev}" in
-                
+
                 *)
                     COMPREPLY=()
                     ;;
@@ -58,7 +58,7 @@ _frum() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        
+
         frum__completions)
             opts=" -l -h -V -s  --list --help --version --shell  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
@@ -66,7 +66,7 @@ _frum() {
                 return 0
             fi
             case "${prev}" in
-                
+
                 --shell)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -89,7 +89,7 @@ _frum() {
                 return 0
             fi
             case "${prev}" in
-                
+
                 *)
                     COMPREPLY=()
                     ;;
@@ -104,7 +104,7 @@ _frum() {
                 return 0
             fi
             case "${prev}" in
-                
+
                 *)
                     COMPREPLY=()
                     ;;
@@ -119,7 +119,7 @@ _frum() {
                 return 0
             fi
             case "${prev}" in
-                
+
                 *)
                     COMPREPLY=()
                     ;;
@@ -134,7 +134,7 @@ _frum() {
                 return 0
             fi
             case "${prev}" in
-                
+
                 *)
                     COMPREPLY=()
                     ;;
@@ -143,13 +143,13 @@ _frum() {
             return 0
             ;;
         frum__local)
-            opts=" -h -V  --help --version  $(frum completions --list) "
+            opts=" -q -h -V  --quiet --help --version  $(frum completions --list) "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                
+
                 *)
                     COMPREPLY=()
                     ;;
@@ -164,7 +164,7 @@ _frum() {
                 return 0
             fi
             case "${prev}" in
-                
+
                 *)
                     COMPREPLY=()
                     ;;
@@ -179,7 +179,7 @@ _frum() {
                 return 0
             fi
             case "${prev}" in
-                
+
                 *)
                     COMPREPLY=()
                     ;;

--- a/completions/frum.zsh
+++ b/completions/frum.zsh
@@ -128,56 +128,56 @@ _frum_commands() {
 (( $+functions[_frum__completions_commands] )) ||
 _frum__completions_commands() {
     local commands; commands=(
-
+        
     )
     _describe -t commands 'frum completions commands' commands "$@"
 }
 (( $+functions[_frum__global_commands] )) ||
 _frum__global_commands() {
     local commands; commands=(
-
+        
     )
     _describe -t commands 'frum global commands' commands "$@"
 }
 (( $+functions[_frum__help_commands] )) ||
 _frum__help_commands() {
     local commands; commands=(
-
+        
     )
     _describe -t commands 'frum help commands' commands "$@"
 }
 (( $+functions[_frum__init_commands] )) ||
 _frum__init_commands() {
     local commands; commands=(
-
+        
     )
     _describe -t commands 'frum init commands' commands "$@"
 }
 (( $+functions[_frum__install_commands] )) ||
 _frum__install_commands() {
     local commands; commands=(
-
+        
     )
     _describe -t commands 'frum install commands' commands "$@"
 }
 (( $+functions[_frum__local_commands] )) ||
 _frum__local_commands() {
     local commands; commands=(
-
+        
     )
     _describe -t commands 'frum local commands' commands "$@"
 }
 (( $+functions[_frum__uninstall_commands] )) ||
 _frum__uninstall_commands() {
     local commands; commands=(
-
+        
     )
     _describe -t commands 'frum uninstall commands' commands "$@"
 }
 (( $+functions[_frum__versions_commands] )) ||
 _frum__versions_commands() {
     local commands; commands=(
-
+        
     )
     _describe -t commands 'frum versions commands' commands "$@"
 }

--- a/completions/frum.zsh
+++ b/completions/frum.zsh
@@ -68,6 +68,8 @@ _arguments "${_arguments_options[@]}" \
 ;;
 (local)
 _arguments "${_arguments_options[@]}" \
+'-q[Supress messages for missing .ruby-version files]' \
+'--quiet[Supress messages for missing .ruby-version files]' \
 '-h[Prints help information]' \
 '--help[Prints help information]' \
 '-V[Prints version information]' \
@@ -126,56 +128,56 @@ _frum_commands() {
 (( $+functions[_frum__completions_commands] )) ||
 _frum__completions_commands() {
     local commands; commands=(
-        
+
     )
     _describe -t commands 'frum completions commands' commands "$@"
 }
 (( $+functions[_frum__global_commands] )) ||
 _frum__global_commands() {
     local commands; commands=(
-        
+
     )
     _describe -t commands 'frum global commands' commands "$@"
 }
 (( $+functions[_frum__help_commands] )) ||
 _frum__help_commands() {
     local commands; commands=(
-        
+
     )
     _describe -t commands 'frum help commands' commands "$@"
 }
 (( $+functions[_frum__init_commands] )) ||
 _frum__init_commands() {
     local commands; commands=(
-        
+
     )
     _describe -t commands 'frum init commands' commands "$@"
 }
 (( $+functions[_frum__install_commands] )) ||
 _frum__install_commands() {
     local commands; commands=(
-        
+
     )
     _describe -t commands 'frum install commands' commands "$@"
 }
 (( $+functions[_frum__local_commands] )) ||
 _frum__local_commands() {
     local commands; commands=(
-        
+
     )
     _describe -t commands 'frum local commands' commands "$@"
 }
 (( $+functions[_frum__uninstall_commands] )) ||
 _frum__uninstall_commands() {
     local commands; commands=(
-        
+
     )
     _describe -t commands 'frum uninstall commands' commands "$@"
 }
 (( $+functions[_frum__versions_commands] )) ||
 _frum__versions_commands() {
     local commands; commands=(
-        
+
     )
     _describe -t commands 'frum versions commands' commands "$@"
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,7 +40,7 @@ pub fn build_cli() -> App<'static, 'static> {
                         .short("q")
                         .long("quiet")
                         .takes_value(false)
-                        .help("Supress messages for missing .ruby-version files")
+                        .help("Supress messages for missing .ruby-version files"),
                 ),
         )
         .subcommand(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,7 +34,14 @@ pub fn build_cli() -> App<'static, 'static> {
         .subcommand(
             SubCommand::with_name("local")
                 .about("Sets the current Ruby version")
-                .arg(Arg::with_name("version").index(1)),
+                .arg(Arg::with_name("version").index(1))
+                .arg(
+                    Arg::with_name("quiet")
+                        .short("q")
+                        .long("quiet")
+                        .takes_value(false)
+                        .help("Supress messages for missing .ruby-version files")
+                ),
         )
         .subcommand(
             SubCommand::with_name("global")

--- a/src/commands/completions.rs
+++ b/src/commands/completions.rs
@@ -11,6 +11,7 @@ const USE_COMMAND_REGEX: &str = r#"opts=" -h -V  --help --version  "#;
 const INSTALL_COMMAND_REGEX: &str =
     r#"opts=" -l -w -h -V  --list --with-openssl-dir --help --version  "#;
 const UNINSTALL_COMMAND_REGEX: &str = r#"opts=" -h -V  --help --version  "#;
+const LOCAL_COMMAND_REGEX: &str = r#"opts=" -q -h -V  --quiet --help --version  "#;
 
 #[derive(Debug)]
 enum FrumCommand {
@@ -102,6 +103,9 @@ fn customize_completions(shell: Shell) -> Option<String> {
     let uninstall_command_regex =
         regex::Regex::new(format!(r#"(\s+){}{} "#, UNINSTALL_COMMAND_REGEX, "<version>").as_str())
             .unwrap();
+    let local_command_regex =
+        regex::Regex::new(format!(r#"(\s+){}{} "#, LOCAL_COMMAND_REGEX, "<version>").as_str())
+            .unwrap();
     match shell {
         Shell::Zsh => {
             for (index, line) in string_split.clone().enumerate() {
@@ -172,16 +176,16 @@ fn customize_completions(shell: Shell) -> Option<String> {
                         "{}\n",
                         match subcommand {
                             FrumCommand::Local =>
-                                if use_command_regex.is_match(line) {
+                                if local_command_regex.is_match(line) {
                                     format!(
                                         r#"{}{}$(frum completions --list) ""#,
-                                        use_command_regex
+                                        local_command_regex
                                             .captures(line)
                                             .unwrap()
                                             .get(1)
                                             .unwrap()
                                             .as_str(),
-                                        USE_COMMAND_REGEX
+                                        LOCAL_COMMAND_REGEX
                                     )
                                 } else {
                                     line.to_string()

--- a/src/commands/local.rs
+++ b/src/commands/local.rs
@@ -20,7 +20,7 @@ pub enum FrumError {
 
 pub struct Local {
     pub version: Option<InputVersion>,
-    pub quiet: bool
+    pub quiet: bool,
 }
 
 impl crate::command::Command for Local {
@@ -34,10 +34,10 @@ impl crate::command::Command for Local {
                     replace_symlink(
                         &config.default_version_dir(),
                         &config
-                        .frum_path
-                        .clone()
-                        .ok_or(FrumError::FrumPathNotFound)?,
-                        )?;
+                            .frum_path
+                            .clone()
+                            .ok_or(FrumError::FrumPathNotFound)?,
+                    )?;
 
                     Err(FrumError::CantInferVersion)
                 }
@@ -46,29 +46,29 @@ impl crate::command::Command for Local {
             Ok(version) => version,
             Err(result) => {
                 if self.quiet {
-                    return Ok(())
+                    return Ok(());
                 }
                 result?
-            },
+            }
         };
         debug!("Use {} as the current version", current_version);
         if !&config
             .versions_dir()
-                .join(current_version.to_string())
-                .exists()
-                {
-                    return Err(FrumError::VersionNotFound {
-                        version: current_version,
-                    });
-                }
+            .join(current_version.to_string())
+            .exists()
+        {
+            return Err(FrumError::VersionNotFound {
+                version: current_version,
+            });
+        }
         replace_symlink(
             &config.versions_dir().join(current_version.to_string()),
             &config
-            .frum_path
-            .clone()
-            .ok_or(FrumError::FrumPathNotFound)?,
-            )
-            .map_err(FrumError::IoError)?;
+                .frum_path
+                .clone()
+                .ok_or(FrumError::FrumPathNotFound)?,
+        )
+        .map_err(FrumError::IoError)?;
         Ok(())
     }
 }
@@ -96,10 +96,10 @@ mod tests {
         let mut config = FrumConfig::default();
         config.base_dir = Some(tempdir().unwrap().path().to_path_buf());
         config.frum_path = Some(std::env::temp_dir().join(format!(
-                    "frum_{}_{}",
-                    std::process::id(),
-                    chrono::Utc::now().timestamp_millis(),
-                    )));
+            "frum_{}_{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_millis(),
+        )));
         let dir_path = config.versions_dir().join("2.6.4").join("bin");
         std::fs::create_dir_all(&dir_path).unwrap();
         File::create(dir_path.join("ruby")).unwrap();
@@ -108,16 +108,16 @@ mod tests {
             version: InputVersion::Full(Version::Semver(semver::Version::parse("2.6.4").unwrap())),
         }
         .apply(&config)
-            .unwrap();
+        .unwrap();
 
         Local {
             version: Some(InputVersion::Full(Version::Semver(
-                                 semver::Version::parse("2.6.4").unwrap(),
-                                 ))),
-                                 quiet: false,
+                semver::Version::parse("2.6.4").unwrap(),
+            ))),
+            quiet: false,
         }
         .apply(&config)
-            .expect("failed to install");
+        .expect("failed to install");
 
         assert!(config.frum_path.unwrap().join("bin").join("ruby").exists());
     }
@@ -127,15 +127,15 @@ mod tests {
         let mut config = FrumConfig::default();
         config.base_dir = Some(tempdir().unwrap().path().to_path_buf());
         config.frum_path = Some(std::env::temp_dir().join(format!(
-                    "frum_{}_{}",
-                    std::process::id(),
-                    chrono::Utc::now().timestamp_millis(),
-                    )));
+            "frum_{}_{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_millis(),
+        )));
         let result = Local {
             version: Some(InputVersion::Full(Version::Semver(
-                                 semver::Version::parse("2.6.4").unwrap(),
-                                 ))),
-                                 quiet: false,
+                semver::Version::parse("2.6.4").unwrap(),
+            ))),
+            quiet: false,
         }
         .apply(&config);
         match result {
@@ -150,10 +150,10 @@ mod tests {
         let mut config = FrumConfig::default();
         config.base_dir = Some(tempdir().unwrap().path().to_path_buf());
         config.frum_path = Some(std::env::temp_dir().join(format!(
-                    "frum_{}_{}",
-                    std::process::id(),
-                    chrono::Utc::now().timestamp_millis(),
-                    )));
+            "frum_{}_{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_millis(),
+        )));
         let result = Local {
             version: None,
             quiet: false,
@@ -171,10 +171,10 @@ mod tests {
         let mut config = FrumConfig::default();
         config.base_dir = Some(tempdir().unwrap().path().to_path_buf());
         config.frum_path = Some(std::env::temp_dir().join(format!(
-                    "frum_{}_{}",
-                    std::process::id(),
-                    chrono::Utc::now().timestamp_millis(),
-                    )));
+            "frum_{}_{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_millis(),
+        )));
         let result = Local {
             version: None,
             quiet: true,

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ fn main() {
                 }
                 None => None,
             },
+            quiet: sub_matches.is_present("quiet"),
         }
         .call(&config),
         ("install", Some(sub_matches)) => {

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -18,7 +18,7 @@ impl Shell for Bash {
             r#"
                 __frumcd() {
                     \cd "$@" || return $?
-                    frum local
+                    frum local --quiet
                 }
 
                 alias cd=__frumcd

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -19,7 +19,7 @@ impl Shell for Fish {
             r#"
                 function _frum_autoload_hook --on-variable PWD --description 'Change Ruby version on directory change'
                     status --is-command-substitution; and return
-                    frum local
+                    frum local --quiet
                 end
             "#
         )

--- a/src/shell/powershell.rs
+++ b/src/shell/powershell.rs
@@ -19,7 +19,8 @@ impl Shell for PowerShell {
     }
 
     fn use_on_cd(&self, _config: &crate::config::FrumConfig) -> String {
-        indoc!(r#"
+        indoc!(
+            r#"
             function Set-LocationWithFrum {
                 param($path)
                 Set-Location $path
@@ -28,7 +29,9 @@ impl Shell for PowerShell {
             Set-Alias cd_with_frum Set-LocationWithFrum -Force
             Remove-Item alias:\cd
             New-Alias cd Set-LocationWithFrum
-        "#).into()
+        "#
+        )
+        .into()
     }
 
     fn into_clap_shell(&self) -> clap::Shell {

--- a/src/shell/powershell.rs
+++ b/src/shell/powershell.rs
@@ -20,7 +20,11 @@ impl Shell for PowerShell {
 
     fn use_on_cd(&self, _config: &crate::config::FrumConfig) -> String {
         indoc!(r#"
-            function Set-LocationWithFrum { param($path); Set-Location $path; If (Test-Path .ruby-version) { & frum local } }
+            function Set-LocationWithFrum {
+                param($path)
+                Set-Location $path
+                If (Test-Path .ruby-version) { & frum local --quiet }
+            }
             Set-Alias cd_with_frum Set-LocationWithFrum -Force
             Remove-Item alias:\cd
             New-Alias cd Set-LocationWithFrum

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -18,7 +18,7 @@ impl Shell for Zsh {
             r#"
                 autoload -U add-zsh-hook
                 _frum_autoload_hook () {
-                    frum local
+                    frum local --quiet
                 }
 
                 add-zsh-hook chpwd _frum_autoload_hook \


### PR DESCRIPTION
Closes #42 

This PR

* adds a `--quiet` (`-q`) flag to the `local` subcommand and
* updates the `use_on_cd` commands for the various shells to use this flag.
