### PR TITLE
Apply clippy lints

### DIFF
--- a/src/commands/completions.rs
+++ b/src/commands/completions.rs
@@ -77,15 +77,12 @@ impl Command for Completions {
             .or_else(|| infer_shell().map(Into::into))
             .ok_or(FrumError::CantInferShell)?;
 
-        print!(
-            "{}",
-            customize_completions(shell).expect("invalid completions")
-        );
+        print!("{}", customize_completions(shell));
         Ok(())
     }
 }
 
-fn customize_completions(shell: Shell) -> Option<String> {
+fn customize_completions(shell: Shell) -> String {
     use std::io::BufWriter;
     let mut buffer = BufWriter::new(Vec::new());
     build_cli().gen_completions_to(env!("CARGO_PKG_NAME"), shell, &mut buffer);
@@ -153,7 +150,7 @@ fn customize_completions(shell: Shell) -> Option<String> {
                     .as_str(),
                 );
             }
-            Some(completions)
+            completions
         }
         Shell::Bash => {
             for (index, line) in string_split.clone().enumerate() {
@@ -241,7 +238,7 @@ fn customize_completions(shell: Shell) -> Option<String> {
                     .as_str(),
                 );
             }
-            Some(completions)
+            completions
         }
         _ => {
             for (index, line) in string_split.clone().enumerate() {
@@ -250,7 +247,7 @@ fn customize_completions(shell: Shell) -> Option<String> {
                 }
                 completions.push_str(format!("{}\n", line).as_str())
             }
-            Some(completions)
+            completions
         }
     }
 }
@@ -266,37 +263,29 @@ fn shells_as_string() -> String {
 #[cfg(test)]
 mod test {
     use super::customize_completions;
-    use crate::config::FrumConfig;
     use clap::Shell;
     use difference::assert_diff;
     use std::fs::File;
     use std::io::prelude::*;
     use std::io::BufReader;
-    use tempfile::tempdir;
 
     #[test]
     fn test_zsh_completions() {
-        let mut config = FrumConfig::default();
-        config.base_dir = Some(tempdir().unwrap().path().to_path_buf());
-
         let file = File::open("completions/frum.zsh").unwrap();
         let mut buf_reader = BufReader::new(file);
         let mut expected = String::new();
         buf_reader.read_to_string(&mut expected).unwrap();
-        let actual = customize_completions(Shell::Zsh).unwrap();
+        let actual = customize_completions(Shell::Zsh);
         assert_diff!(actual.as_str(), expected.as_str(), "\n", 0);
     }
 
     #[test]
     fn test_bash_completions() {
-        let mut config = FrumConfig::default();
-        config.base_dir = Some(tempdir().unwrap().path().to_path_buf());
-
         let file = File::open("completions/frum.bash").unwrap();
         let mut buf_reader = BufReader::new(file);
         let mut expected = String::new();
         buf_reader.read_to_string(&mut expected).unwrap();
-        let actual = customize_completions(Shell::Bash).unwrap();
+        let actual = customize_completions(Shell::Bash);
         assert_diff!(actual.as_str(), expected.as_str(), "\n", 0);
     }
 }

--- a/src/commands/global.rs
+++ b/src/commands/global.rs
@@ -42,13 +42,15 @@ mod tests {
 
     #[test]
     fn test_global_specified_version() {
-        let mut config = FrumConfig::default();
-        config.base_dir = Some(tempdir().unwrap().path().to_path_buf());
-        config.frum_path = Some(std::env::temp_dir().join(format!(
-            "frum_{}_{}",
-            std::process::id(),
-            chrono::Utc::now().timestamp_millis(),
-        )));
+        let config = FrumConfig {
+            base_dir: Some(tempdir().unwrap().path().to_path_buf()),
+            frum_path: Some(std::env::temp_dir().join(format!(
+                "frum_{}_{}",
+                std::process::id(),
+                chrono::Utc::now().timestamp_millis(),
+            ))),
+            ..Default::default()
+        };
         let dir_path = config.versions_dir().join("2.6.4").join("bin");
         std::fs::create_dir_all(&dir_path).unwrap();
         File::create(dir_path.join("ruby")).unwrap();

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -95,7 +95,7 @@ impl crate::command::Command for Install {
             });
         }
 
-        outln!(config#Info, "{} Extracting {}", "==>".green(), format!("{}", archive(&version)).green());
+        outln!(config#Info, "{} Extracting {}", "==>".green(), archive(&version).green());
         let temp_installations_dir = installations_dir.join(".downloads");
         std::fs::create_dir_all(&temp_installations_dir).map_err(FrumError::IoError)?;
         let temp_dir = tempfile::TempDir::new_in(&temp_installations_dir)
@@ -265,6 +265,7 @@ fn number_of_cores() -> Result<u8, FrumError> {
         .expect("can't convert cores to integer"))
 }
 
+#[allow(clippy::unnecessary_wraps)]
 fn openssl_dir() -> Result<String, FrumError> {
     #[cfg(target_os = "macos")]
     return Ok(String::from_utf8_lossy(
@@ -291,8 +292,11 @@ mod tests {
 
     #[test]
     fn test_install_second_version() {
-        let mut config = FrumConfig::default();
-        config.base_dir = Some(tempdir().unwrap().path().to_path_buf());
+        let config = FrumConfig {
+            base_dir: Some(tempdir().unwrap().path().to_path_buf()),
+            ..Default::default()
+        };
+
         Install {
             version: Some(InputVersion::Full(Version::Semver(
                 semver::Version::parse("2.7.0").unwrap(),
@@ -320,8 +324,10 @@ mod tests {
 
     #[test]
     fn test_install_default_version() {
-        let mut config = FrumConfig::default();
-        config.base_dir = Some(tempdir().unwrap().path().to_path_buf());
+        let config = FrumConfig {
+            base_dir: Some(tempdir().unwrap().path().to_path_buf()),
+            ..Default::default()
+        };
 
         Install {
             version: Some(InputVersion::Full(Version::Semver(

--- a/src/commands/local.rs
+++ b/src/commands/local.rs
@@ -93,13 +93,15 @@ mod tests {
 
     #[test]
     fn test_local_specified_version() {
-        let mut config = FrumConfig::default();
-        config.base_dir = Some(tempdir().unwrap().path().to_path_buf());
-        config.frum_path = Some(std::env::temp_dir().join(format!(
-            "frum_{}_{}",
-            std::process::id(),
-            chrono::Utc::now().timestamp_millis(),
-        )));
+        let config = FrumConfig {
+            base_dir: Some(tempdir().unwrap().path().to_path_buf()),
+            frum_path: Some(std::env::temp_dir().join(format!(
+                "frum_{}_{}",
+                std::process::id(),
+                chrono::Utc::now().timestamp_millis(),
+            ))),
+            ..Default::default()
+        };
         let dir_path = config.versions_dir().join("2.6.4").join("bin");
         std::fs::create_dir_all(&dir_path).unwrap();
         File::create(dir_path.join("ruby")).unwrap();
@@ -124,13 +126,15 @@ mod tests {
 
     #[test]
     fn test_not_found_version() {
-        let mut config = FrumConfig::default();
-        config.base_dir = Some(tempdir().unwrap().path().to_path_buf());
-        config.frum_path = Some(std::env::temp_dir().join(format!(
-            "frum_{}_{}",
-            std::process::id(),
-            chrono::Utc::now().timestamp_millis(),
-        )));
+        let config = FrumConfig {
+            base_dir: Some(tempdir().unwrap().path().to_path_buf()),
+            frum_path: Some(std::env::temp_dir().join(format!(
+                "frum_{}_{}",
+                std::process::id(),
+                chrono::Utc::now().timestamp_millis(),
+            ))),
+            ..FrumConfig::default()
+        };
         let result = Local {
             version: Some(InputVersion::Full(Version::Semver(
                 semver::Version::parse("2.6.4").unwrap(),
@@ -138,52 +142,45 @@ mod tests {
             quiet: false,
         }
         .apply(&config);
-        match result {
-            Ok(_) => assert!(false),
-            Err(FrumError::VersionNotFound { .. }) => assert!(true),
-            _ => assert!(false),
-        }
+        assert!(matches!(result, Err(FrumError::VersionNotFound { .. })));
     }
 
     #[test]
     fn test_not_found_version_file() {
-        let mut config = FrumConfig::default();
-        config.base_dir = Some(tempdir().unwrap().path().to_path_buf());
-        config.frum_path = Some(std::env::temp_dir().join(format!(
-            "frum_{}_{}",
-            std::process::id(),
-            chrono::Utc::now().timestamp_millis(),
-        )));
+        let config = FrumConfig {
+            base_dir: Some(tempdir().unwrap().path().to_path_buf()),
+            frum_path: Some(std::env::temp_dir().join(format!(
+                "frum_{}_{}",
+                std::process::id(),
+                chrono::Utc::now().timestamp_millis(),
+            ))),
+            ..FrumConfig::default()
+        };
         std::env::set_current_dir(std::env::temp_dir()).unwrap();
         let result = Local {
             version: None,
             quiet: false,
         }
         .apply(&config);
-        match result {
-            Ok(_) => assert!(false),
-            Err(FrumError::CantInferVersion { .. }) => assert!(true),
-            _ => assert!(false),
-        }
+        assert!(matches!(result, Err(FrumError::CantInferVersion)));
     }
 
     #[test]
     fn test_not_found_version_file_with_quiet() {
-        let mut config = FrumConfig::default();
-        config.base_dir = Some(tempdir().unwrap().path().to_path_buf());
-        config.frum_path = Some(std::env::temp_dir().join(format!(
-            "frum_{}_{}",
-            std::process::id(),
-            chrono::Utc::now().timestamp_millis(),
-        )));
+        let config = FrumConfig {
+            base_dir: Some(tempdir().unwrap().path().to_path_buf()),
+            frum_path: Some(std::env::temp_dir().join(format!(
+                "frum_{}_{}",
+                std::process::id(),
+                chrono::Utc::now().timestamp_millis(),
+            ))),
+            ..FrumConfig::default()
+        };
         let result = Local {
             version: None,
             quiet: true,
         }
         .apply(&config);
-        match result {
-            Ok(()) => assert!(true),
-            _ => assert!(false),
-        }
+        assert!(matches!(result, Ok(())));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,9 @@ fn main() {
         }
         .call(&config),
         ("local", Some(sub_matches)) => commands::local::Local {
-            version: sub_matches.value_of("version").map(|version| input_version::InputVersion::from_str(version).expect("invalid version")),
+            version: sub_matches.value_of("version").map(|version| {
+                input_version::InputVersion::from_str(version).expect("invalid version")
+            }),
             quiet: sub_matches.is_present("quiet"),
         }
         .call(&config),
@@ -44,7 +46,9 @@ fn main() {
                 return;
             }
             commands::install::Install {
-                version: sub_matches.value_of("version").map(|version| input_version::InputVersion::from_str(version).expect("invalid version")),
+                version: sub_matches.value_of("version").map(|version| {
+                    input_version::InputVersion::from_str(version).expect("invalid version")
+                }),
             }
             .call(&config);
         }
@@ -59,7 +63,9 @@ fn main() {
         }
         ("completions", Some(sub_matches)) => {
             commands::completions::Completions {
-                shell: sub_matches.value_of("shell").map(|shell| clap::Shell::from_str(shell).expect("invalid shell")),
+                shell: sub_matches
+                    .value_of("shell")
+                    .map(|shell| clap::Shell::from_str(shell).expect("invalid shell")),
                 list: sub_matches.is_present("list"),
             }
             .call(&config);

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,12 +34,7 @@ fn main() {
         }
         .call(&config),
         ("local", Some(sub_matches)) => commands::local::Local {
-            version: match sub_matches.value_of("version") {
-                Some(version) => {
-                    Some(input_version::InputVersion::from_str(version).expect("invalid version"))
-                }
-                None => None,
-            },
+            version: sub_matches.value_of("version").map(|version| input_version::InputVersion::from_str(version).expect("invalid version")),
             quiet: sub_matches.is_present("quiet"),
         }
         .call(&config),
@@ -49,12 +44,7 @@ fn main() {
                 return;
             }
             commands::install::Install {
-                version: match sub_matches.value_of("version") {
-                    Some(version) => Some(
-                        input_version::InputVersion::from_str(version).expect("invalid version"),
-                    ),
-                    None => None,
-                },
+                version: sub_matches.value_of("version").map(|version| input_version::InputVersion::from_str(version).expect("invalid version")),
             }
             .call(&config);
         }
@@ -69,10 +59,7 @@ fn main() {
         }
         ("completions", Some(sub_matches)) => {
             commands::completions::Completions {
-                shell: match sub_matches.value_of("shell") {
-                    Some(shell) => Some(clap::Shell::from_str(shell).expect("invalid shell")),
-                    None => None,
-                },
+                shell: sub_matches.value_of("shell").map(|shell| clap::Shell::from_str(shell).expect("invalid shell")),
                 list: sub_matches.is_present("list"),
             }
             .call(&config);

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -27,7 +27,7 @@ impl Shell for Bash {
         .into()
     }
 
-    fn into_clap_shell(&self) -> clap::Shell {
+    fn as_clap_shell(&self) -> clap::Shell {
         clap::Shell::Bash
     }
 }

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -26,7 +26,7 @@ impl Shell for Fish {
         .into()
     }
 
-    fn into_clap_shell(&self) -> clap::Shell {
+    fn as_clap_shell(&self) -> clap::Shell {
         clap::Shell::Fish
     }
 }

--- a/src/shell/infer/windows.rs
+++ b/src/shell/infer/windows.rs
@@ -66,7 +66,7 @@ pub fn get_process_map() -> std::io::Result<ProcessMap> {
         .stdout(std::process::Stdio::piped())
         .spawn()?
         .stdout
-        .ok_or(std::io::Error::from(std::io::ErrorKind::UnexpectedEof))?;
+        .ok_or_else(|| std::io::Error::from(std::io::ErrorKind::UnexpectedEof))?;
 
     let mut reader = csv::Reader::from_reader(stdout);
     let hashmap: HashMap<_, _> = reader

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -17,7 +17,7 @@ pub trait Shell: Debug {
     fn path(&self, path: &Path) -> String;
     fn set_env_var(&self, name: &str, value: &str) -> String;
     fn use_on_cd(&self, config: &crate::config::FrumConfig) -> String;
-    fn into_clap_shell(&self) -> clap::Shell;
+    fn as_clap_shell(&self) -> clap::Shell;
 }
 
 #[cfg(windows)]
@@ -38,6 +38,6 @@ pub fn infer_shell() -> Option<Box<dyn Shell>> {
 
 impl From<Box<dyn Shell>> for clap::Shell {
     fn from(shell: Box<dyn Shell>) -> clap::Shell {
-        shell.into_clap_shell()
+        shell.as_clap_shell()
     }
 }

--- a/src/shell/powershell.rs
+++ b/src/shell/powershell.rs
@@ -34,7 +34,7 @@ impl Shell for PowerShell {
         .into()
     }
 
-    fn into_clap_shell(&self) -> clap::Shell {
+    fn as_clap_shell(&self) -> clap::Shell {
         clap::Shell::PowerShell
     }
 }

--- a/src/shell/windows_command/mod.rs
+++ b/src/shell/windows_command/mod.rs
@@ -26,7 +26,7 @@ impl Shell for WindowsCommand {
         )
     }
 
-    fn into_clap_shell(&self) -> clap::Shell {
+    fn as_clap_shell(&self) -> clap::Shell {
         panic!("Shell completion is not supported for Windows Command Prompt. Maybe try using PowerShell for a better experience?");
     }
 }

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -28,7 +28,7 @@ impl Shell for Zsh {
         .into()
     }
 
-    fn into_clap_shell(&self) -> clap::Shell {
+    fn as_clap_shell(&self) -> clap::Shell {
         clap::Shell::Zsh
     }
 }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -13,7 +13,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
 use std::time::Duration;
 
-static TEST_DIR: &'static str = "frum-tests";
+static TEST_DIR: &str = "frum-tests";
 static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
 
 /// Setup an empty work directory and return a command pointing to the frum
@@ -32,7 +32,7 @@ pub fn setup(test_name: &str) -> (Dir, TestCommand) {
 /// always be in the same order.
 pub fn sort_lines(lines: &str) -> String {
     let mut lines: Vec<&str> = lines.trim().lines().collect();
-    lines.sort();
+    lines.sort_unstable();
     format!("{}\n", lines.join("\n"))
 }
 
@@ -78,7 +78,7 @@ impl Dir {
         nice_err(&dir, repeat(|| fs::create_dir_all(&dir)));
         let (frum_path, path) = set_frum_path_env(&root, &dir);
         Dir {
-            root: root,
+            root,
             dir,
             frum_path,
             ruby_bin_path: path,
@@ -137,7 +137,7 @@ impl Dir {
             .env("FRUM_DIR", self.dir.to_str().unwrap());
         TestCommand {
             dir: self.clone(),
-            cmd: cmd,
+            cmd,
         }
     }
 


### PR DESCRIPTION
Applied Clippy lints with `cargo clippy --fix` and manually refactored some to make Clippy report 0 warnings :)

Notes:

- will every supported shell have completions? if not, changing signature of `customize_completions` might've been a bad move.