### PR TITLE
Replace `--quiet` with common `--log-level` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ add the following to your `.zshrc`:
 eval "$(frum init)"
 ```
 
+### Options
+
+- --log-level: The log level of frum commands [default: info] [possible values: quiet, info, error].
+
 ### Subcommands
 
 - init: Sets environment variables for initializing frum.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ eval "$(frum init)"
 - versions: Lists installed Ruby versions.
 - global: Sets the global Ruby version.
 - local: Sets the current Ruby version.
-    - -q, --quiet: Supress error messages when `.ruby-version` is missing
 
 ## Installation
 

--- a/completions/frum.bash
+++ b/completions/frum.bash
@@ -147,7 +147,7 @@ _frum() {
             return 0
             ;;
         frum__local)
-            opts=" -h -V  --help --version  <version> "
+            opts=" -h -V  --help --version  $(frum completions --list) "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/completions/frum.bash
+++ b/completions/frum.bash
@@ -44,13 +44,17 @@ _frum() {
 
     case "${cmd}" in
         frum)
-            opts=" -h -V  --help --version   init install uninstall versions local global completions help"
+            opts=" -h -V  --help --version --log-level   init install uninstall versions local global completions help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
                 
+                --log-level)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -143,7 +147,7 @@ _frum() {
             return 0
             ;;
         frum__local)
-            opts=" -q -h -V  --quiet --help --version  $(frum completions --list) "
+            opts=" -h -V  --help --version  <version> "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/completions/frum.zsh
+++ b/completions/frum.zsh
@@ -15,6 +15,7 @@ _frum() {
 
     local context curcontext="$curcontext" state line
     _arguments "${_arguments_options[@]}" \
+'--log-level=[The log level of frum commands]' \
 '-h[Prints help information]' \
 '--help[Prints help information]' \
 '-V[Prints version information]' \
@@ -68,8 +69,6 @@ _arguments "${_arguments_options[@]}" \
 ;;
 (local)
 _arguments "${_arguments_options[@]}" \
-'-q[Supress messages for missing .ruby-version files]' \
-'--quiet[Supress messages for missing .ruby-version files]' \
 '-h[Prints help information]' \
 '--help[Prints help information]' \
 '-V[Prints version information]' \

--- a/completions/frum.zsh
+++ b/completions/frum.zsh
@@ -15,7 +15,7 @@ _frum() {
 
     local context curcontext="$curcontext" state line
     _arguments "${_arguments_options[@]}" \
-'--log-level=[The log level of frum commands]' \
+'--log-level=[The log level of frum commands \[default: info\] \[possible values: quiet, info, error\]]' \
 '-h[Prints help information]' \
 '--help[Prints help information]' \
 '-V[Prints version information]' \

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,7 +8,7 @@ pub fn build_cli() -> App<'static, 'static> {
         .arg(
             Arg::with_name("log-level")
                 .long("log-level")
-                .help("The log level of frum commands")
+                .help("The log level of frum commands [default: info] [possible values: quiet, info, error]")
                 .takes_value(true),
         )
         .subcommand(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,6 +5,12 @@ pub fn build_cli() -> App<'static, 'static> {
         .setting(AppSettings::ArgRequiredElseHelp)
         .version("1.0")
         .about("A blazing fast Ruby version manager written in Rust")
+        .arg(
+            Arg::with_name("log-level")
+                .long("log-level")
+                .help("The log level of frum commands")
+                .takes_value(true),
+        )
         .subcommand(
             SubCommand::with_name("init").about("Sets environment variables for initializing frum"),
         )
@@ -34,14 +40,7 @@ pub fn build_cli() -> App<'static, 'static> {
         .subcommand(
             SubCommand::with_name("local")
                 .about("Sets the current Ruby version")
-                .arg(Arg::with_name("version").index(1))
-                .arg(
-                    Arg::with_name("quiet")
-                        .short("q")
-                        .long("quiet")
-                        .takes_value(false)
-                        .help("Supress messages for missing .ruby-version files"),
-                ),
+                .arg(Arg::with_name("version").index(1)),
         )
         .subcommand(
             SubCommand::with_name("global")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,8 +3,8 @@ use clap::{App, AppSettings, Arg, SubCommand};
 pub fn build_cli() -> App<'static, 'static> {
     App::new("frum")
         .setting(AppSettings::ArgRequiredElseHelp)
-        .version("1.0")
-        .about("A blazing fast Ruby version manager written in Rust")
+        .version("0.1.0-alpha.1")
+        .about("A little bit fast and modern Ruby version manager written in Rust")
         .arg(
             Arg::with_name("log-level")
                 .long("log-level")

--- a/src/commands/completions.rs
+++ b/src/commands/completions.rs
@@ -11,7 +11,7 @@ const USE_COMMAND_REGEX: &str = r#"opts=" -h -V  --help --version  "#;
 const INSTALL_COMMAND_REGEX: &str =
     r#"opts=" -l -w -h -V  --list --with-openssl-dir --help --version  "#;
 const UNINSTALL_COMMAND_REGEX: &str = r#"opts=" -h -V  --help --version  "#;
-const LOCAL_COMMAND_REGEX: &str = r#"opts=" -q -h -V  --quiet --help --version  "#;
+const LOCAL_COMMAND_REGEX: &str = r#"opts=" -h -V  --help --version  "#;
 
 #[derive(Debug)]
 enum FrumCommand {

--- a/src/log.rs
+++ b/src/log.rs
@@ -5,11 +5,29 @@ pub enum LogLevel {
     Info,
 }
 
+impl Default for LogLevel {
+    fn default() -> Self {
+        Self::Info
+    }
+}
+
 impl LogLevel {
+    pub fn is_writable(&self, level: &Self) -> bool {
+        use std::cmp::Ordering;
+        match self.cmp(level) {
+            Ordering::Greater | Ordering::Equal => true,
+            _ => false,
+        }
+    }
+
     pub fn write(&self, level: &Self) -> Box<dyn std::io::Write> {
-        match level {
-            Self::Error => Box::from(std::io::stderr()),
-            _ => Box::from(std::io::stdout()),
+        if self.is_writable(level) {
+            match level {
+                Self::Error => Box::from(std::io::stderr()),
+                _ => Box::from(std::io::stdout()),
+            }
+        } else {
+            Box::from(std::io::sink())
         }
     }
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -14,10 +14,7 @@ impl Default for LogLevel {
 impl LogLevel {
     pub fn is_writable(&self, level: &Self) -> bool {
         use std::cmp::Ordering;
-        match self.cmp(level) {
-            Ordering::Greater | Ordering::Equal => true,
-            _ => false,
-        }
+        matches!(self.cmp(level), Ordering::Greater | Ordering::Equal)
     }
 
     pub fn write(&self, level: &Self) -> Box<dyn std::io::Write> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,13 @@ fn main() {
     env_logger::init();
     let matches = cli::build_cli().get_matches();
 
-    let config = config::FrumConfig::default();
+    let config = config::FrumConfig {
+        log_level: match matches.value_of("log-level") {
+            Some(log_level) => log::LogLevel::from_str(log_level).expect("invalid log level"),
+            None => log::LogLevel::default(),
+        },
+        ..config::FrumConfig::default()
+    };
     // println!("{:?}", config);
     match matches.subcommand() {
         ("init", _) => commands::init::Init {}.call(&config),
@@ -37,7 +43,6 @@ fn main() {
             version: sub_matches.value_of("version").map(|version| {
                 input_version::InputVersion::from_str(version).expect("invalid version")
             }),
-            quiet: sub_matches.is_present("quiet"),
         }
         .call(&config),
         ("install", Some(sub_matches)) => {

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -18,7 +18,7 @@ impl Shell for Bash {
             r#"
                 __frumcd() {
                     \cd "$@" || return $?
-                    frum local --quiet
+                    frum --log-level quiet local
                 }
 
                 alias cd=__frumcd

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -19,7 +19,7 @@ impl Shell for Fish {
             r#"
                 function _frum_autoload_hook --on-variable PWD --description 'Change Ruby version on directory change'
                     status --is-command-substitution; and return
-                    frum local --quiet
+                    frum --log-level quiet local
                 end
             "#
         )

--- a/src/shell/powershell.rs
+++ b/src/shell/powershell.rs
@@ -24,7 +24,7 @@ impl Shell for PowerShell {
             function Set-LocationWithFrum {
                 param($path)
                 Set-Location $path
-                If (Test-Path .ruby-version) { & frum local --quiet }
+                If (Test-Path .ruby-version) { & frum --log-level quiet local }
             }
             Set-Alias cd_with_frum Set-LocationWithFrum -Force
             Remove-Item alias:\cd

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -18,7 +18,7 @@ impl Shell for Zsh {
             r#"
                 autoload -U add-zsh-hook
                 _frum_autoload_hook () {
-                    frum local --quiet
+                    frum --log-level quiet local
                 }
 
                 add-zsh-hook chpwd _frum_autoload_hook \

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -35,5 +35,9 @@ e2e_test!(use_version_specified_in_ruby_version_file, |dir| {
         "error: Can't find version in dotfiles. Please provide a version manually to the command.\n",
         dir.command().arg("local").stderr()
     );
-    dir.command().arg("--log-level quiet").arg("local").output();
+    dir.command()
+        .arg("--log-level")
+        .arg("quiet")
+        .arg("local")
+        .output();
 });

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -35,5 +35,5 @@ e2e_test!(use_version_specified_in_ruby_version_file, |dir| {
         "error: Can't find version in dotfiles. Please provide a version manually to the command.\n",
         dir.command().arg("local").stderr()
     );
-    dir.command().arg("local").arg("--quiet").output();
+    dir.command().arg("--log-level quiet").arg("local").output();
 });

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -35,9 +35,12 @@ e2e_test!(use_version_specified_in_ruby_version_file, |dir| {
         "error: Can't find version in dotfiles. Please provide a version manually to the command.\n",
         dir.command().arg("local").stderr()
     );
-    dir.command()
-        .arg("--log-level")
-        .arg("quiet")
-        .arg("local")
-        .output();
+    eq!(
+        "",
+        dir.command()
+            .arg("--log-level")
+            .arg("quiet")
+            .arg("local")
+            .stderr()
+    );
 });


### PR DESCRIPTION
`--quiet` in local command has a bug. This is due to my lack of review. To be specific, `frum local --quiet` doesn't read　`.ruby-version` and change current ruby version.

This pull request solves this problem with implementing `--log-level` option and replacing `--quiet` with `--log-level`.

Ref https://github.com/TaKO8Ki/frum/pull/43, https://github.com/TaKO8Ki/frum/issues/39

changelog: replace `--quiet` with common `--log-level` option