### PR TITLE
Add arch linux installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ If you’re using Arch Linux, install the `frum-bin` package using your favorite
 $ yay -S frum-bin
 ```
 
-
 ## Contribution
 
 Contributions, issues and pull requests are welcome!

--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ If you already have a Rust environment set up, you can use the `cargo install` c
 $ cargo install --version 0.1.0-beta.0 frum
 ```
 
+### Arch Linux
+
+If you’re using Arch Linux, install the `frum-bin` package using your favorite AUR helper.
+
+```
+$ yay -S frum-bin
+```
+
+
 ## Contribution
 
 Contributions, issues and pull requests are welcome!


### PR DESCRIPTION
I have created and will maintain an AUR package for Arch Linux. You can find it at https://aur.archlinux.org/packages/frum-bin.