### PR TITLE
Add `num_cpus` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,6 +358,7 @@ dependencies = [
  "env_logger",
  "indoc",
  "log",
+ "num_cpus",
  "regex",
  "reqwest",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ dirs = "3.0.1"
 indoc = "1.0.3"
 encoding_rs_io = "0.1.7"
 zip = "0.5.11"
+num_cpus = "1.13.0"
 
 [target.'cfg(windows)'.dependencies]
 csv = "1.1.5"


### PR DESCRIPTION
This PR replaces the custom code for finding the number of available CPU cores with the [`num_cpus`](https://docs.rs/crate/num_cpus/1.13.0) crate. This should get us a little closer to Windows support as the current code did not take Windows into account. I plan to eventually also look into other Windows-related problems even though my main development OS is Linux.

changelog:

* Add `num_cpus` crate