### PR TITLE
Add frum clean command

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ frum init | source
 - **versions**: Lists installed Ruby versions.
 - **global**: Sets the global Ruby version.
 - **local**: Sets the current Ruby version.
+- **clean**: Remove old downloads.
 
 ### Ruby configuration options
 

--- a/completions/frum.bash
+++ b/completions/frum.bash
@@ -13,6 +13,9 @@ _frum() {
                 cmd="frum"
                 ;;
             
+            clean)
+                cmd+="__clean"
+                ;;
             completions)
                 cmd+="__completions"
                 ;;
@@ -44,7 +47,7 @@ _frum() {
 
     case "${cmd}" in
         frum)
-            opts=" -h -V  --help --version --log-level --ruby-build-mirror --frum-dir   init install uninstall versions local global completions help"
+            opts=" -h -V  --help --version --log-level --ruby-build-mirror --frum-dir   init install uninstall versions local global completions clean help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -71,6 +74,21 @@ _frum() {
             return 0
             ;;
         
+        frum__clean)
+            opts=" -h -V  --help --version  "
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         frum__completions)
             opts=" -l -h -V -s  --list --help --version --shell  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then

--- a/completions/frum.zsh
+++ b/completions/frum.zsh
@@ -102,6 +102,14 @@ _arguments "${_arguments_options[@]}" \
 '--version[Prints version information]' \
 && ret=0
 ;;
+(clean)
+_arguments "${_arguments_options[@]}" \
+'-h[Prints help information]' \
+'--help[Prints help information]' \
+'-V[Prints version information]' \
+'--version[Prints version information]' \
+&& ret=0
+;;
 (help)
 _arguments "${_arguments_options[@]}" \
 '-h[Prints help information]' \
@@ -125,9 +133,17 @@ _frum_commands() {
 "local:Sets the current Ruby version" \
 "global:Sets the global Ruby version" \
 "completions:Print shell completions to stdout" \
+"clean:Remove all downloads" \
 "help:Prints this message or the help of the given subcommand(s)" \
     )
     _describe -t commands 'frum commands' commands "$@"
+}
+(( $+functions[_frum__clean_commands] )) ||
+_frum__clean_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'frum clean commands' commands "$@"
 }
 (( $+functions[_frum__completions_commands] )) ||
 _frum__completions_commands() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -78,4 +78,7 @@ pub fn build_cli() -> App<'static, 'static> {
                         .hidden(true),
                 ),
         )
+        .subcommand(
+            SubCommand::with_name("clean").about("Remove all downloads")
+        )
 }

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -1,0 +1,48 @@
+use crate::outln;
+use colored::Colorize;
+use std::fs;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum FrumError {}
+
+pub struct Clean {}
+
+impl crate::command::Command for Clean {
+    type Error = FrumError;
+
+    fn apply(&self, config: &crate::config::FrumConfig) -> Result<(), Self::Error> {
+        let temp_installations_dir = config.temp_installations_dir();
+        outln!(config#Info, "{} Removing old downloads", "==>".green());
+        fs::remove_dir_all(&temp_installations_dir).expect("Couldn't remove downloads");
+        fs::create_dir(&temp_installations_dir)
+            .expect("Couldn't create temporary installation directory");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::command::Command;
+    use crate::config::FrumConfig;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_remove_downloads() {
+        let config = FrumConfig {
+            base_dir: Some(tempdir().unwrap().path().to_path_buf()),
+            ..Default::default()
+        };
+
+        let temp_installations_dir = config.temp_installations_dir();
+        fs::create_dir_all(&temp_installations_dir)
+            .expect("Can't generate temporary installation directory");
+        tempfile::TempDir::new_in(&temp_installations_dir)
+            .expect("Can't generate temporary directory");
+
+        Clean {}.apply(&config).unwrap();
+
+        assert!(temp_installations_dir.read_dir().unwrap().next().is_none());
+    }
+}

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -96,7 +96,7 @@ impl crate::command::Command for Install {
         }
 
         outln!(config#Info, "{} Extracting {}", "==>".green(), archive(&version).green());
-        let temp_installations_dir = installations_dir.join(".downloads");
+        let temp_installations_dir = config.temp_installations_dir();
         std::fs::create_dir_all(&temp_installations_dir).map_err(FrumError::IoError)?;
         let temp_dir = tempfile::TempDir::new_in(&temp_installations_dir)
             .expect("Can't generate a temp directory");

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod clean;
 pub mod completions;
 pub mod global;
 pub mod init;

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,6 +42,10 @@ impl FrumConfig {
     pub fn aliases_dir(&self) -> std::path::PathBuf {
         ensure_dir_exists(self.base_dir().join("aliases"))
     }
+
+    pub fn temp_installations_dir(&self) -> std::path::PathBuf {
+        self.versions_dir().join(".downloads")
+    }
 }
 
 fn ensure_dir_exists<T: AsRef<std::path::Path>>(path: T) -> T {

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,7 @@ fn main() {
             }
             .call(&config);
         }
+        ("clean", _) => commands::clean::Clean {}.call(&config),
         _ => (),
     };
 }


### PR DESCRIPTION
This PR adds a `frum clean` command for removing old downloads from the temporary installation directory (default: `~/.frum/versions/.downloads`). This removed ~3GB of old downloads for me. It's also one of the steps mentioned in #78.

changelog:

* Add `frum clean` command
