### PR TITLE
Add a benchmark result for `init`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ### Benchmark
 
-`eval "$(frum init)"` is about 6 times faster than `eval "$(rbenv init -)"`.
+`eval "$(frum init)"` runs about 6 times faster than `eval "$(rbenv init -)"`.
 
 | Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
 |:---|---:|---:|---:|---:|

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@
 
 ### Benchmark
 
+`eval "$(frum init)"` is about 6 times faster than `eval "$(rbenv init -)"`.
+
+| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
+|:---|---:|---:|---:|---:|
+| `eval "$(rbenv init -)"` | 49.5 ± 2.1 | 46.2 | 57.2 | 6.14 ± 0.50 |
+| `eval "$(frum init)"` | 8.1 ± 0.7 | 7.0 | 11.8 | 1.00 ± 0.11 |
+| `eval "$(~/.frum-latest/frum init)"` | 8.1 ± 0.6 | 7.2 | 11.7 | 1.00 |
+
 | Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
 |:---|---:|---:|---:|---:|
 | `rbenv` | 239628.1 ± 2030.2 | 237681.6 | 245162.6 | 1.04 ± 0.01 |

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 |:---|---:|---:|---:|---:|
 | `eval "$(rbenv init -)"` | 49.5 ± 2.1 | 46.2 | 57.2 | 6.14 ± 0.50 |
 | `eval "$(frum init)"` | 8.1 ± 0.7 | 7.0 | 11.8 | 1.00 ± 0.11 |
-| `eval "$(~/.frum-latest/frum init)"` | 8.1 ± 0.6 | 7.2 | 11.7 | 1.00 |
+| `eval "$(frum init)"`(pre-release) | 8.1 ± 0.6 | 7.2 | 11.7 | 1.00 |
 
 | Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
 |:---|---:|---:|---:|---:|


### PR DESCRIPTION
changelog: add a benchmark result for `frum init` and `rbenv init`
