### PR TITLE
Add support for mksh

### DIFF
--- a/src/shell/infer/unix.rs
+++ b/src/shell/infer/unix.rs
@@ -26,7 +26,7 @@ pub fn infer_shell() -> Option<Box<dyn Shell>> {
             .expect("Can't read file name of process tree");
 
         match binary {
-            "sh" | "bash" => return Some(Box::from(Bash)),
+            "sh" | "bash" | "mksh" => return Some(Box::from(Bash)),
             "zsh" => return Some(Box::from(Zsh)),
             "fish" => return Some(Box::from(Fish)),
             "pwsh" => return Some(Box::from(PowerShell)),


### PR DESCRIPTION
`frum init` produces an error about not being able to infer the shell
when ran under mksh.

From looking at frum's source and documentation, the `__frumcd`
shell function and the `eval` and `frum init` commands for bash all
seem like they will work just fine with mksh. I added mksh alongside
bash and sh and rebuilt frum and everything is working well for me.

I do not currently have access to other ksh derivatives to test with,
and I am not sure of the current state of ksh derivative support in the
"shell" crate. But this simple change has me up and running and enjoying
frum.

changelog: Add support for mksh by leveraging the existing bash/sh shell functionality
