### PR TITLE
Use pkg-config for determining the OpenSSL path instead of using /usr/local by default under Linux

### DIFF
--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -174,7 +174,18 @@ fn openssl_dir() -> Result<String, FrumError> {
     )
     .trim()
     .to_string());
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "linux")]
+    return Ok(String::from_utf8_lossy(
+        &Command::new("pkg-config")
+            .arg("--variable=prefix")
+            .arg("openssl")
+            .output()
+            .map_err(FrumError::IoError)?
+            .stdout,
+    )
+    .trim()
+    .to_string());
+    #[cfg(all(not(target_os = "macos"), not(target_os = "linux")))]
     return Ok("/usr/local".to_string());
 }
 


### PR DESCRIPTION
Pretty much any modern Linux distribution is using [`pkg-config`](https://www.freedesktop.org/wiki/Software/pkg-config/) these days to share a few common details about the way packages are configured and installed on the host system. The `openssl` package (at least under Ubuntu/Debian) exposes the prefix it is installed under with the `prefix` variable in `pkg-config`.

These modifications are using `pkg-config` to determine the prefix for `openssl`.

Using `/usr/local` as a default will fail to build Ruby with OpenSSL support, "silently" (it's just not detected at compile time), with the symptom simply being that any Ruby built with `frum` won't have TLS/SSL support. This is especially relevant for the latest Ubuntu release (22.04, Jammy Jellyfish) since it ships with OpenSSL 3.x for which there currently is [no support in the OpenSSL gem](https://github.com/ruby/openssl/issues/369).